### PR TITLE
[edit][s]: refactor pushBlob method and fix tests - #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,24 @@ Upload file from **NodeJS**
 
 ```js
 const { Client } = require('./lib/index')
+const f11s = require('data.js')
 
 const client = new Client('key', 'organization-name', 'dataset-name', 'apiUrl')
+const resource = f11s.open(file_path)
 
-client._pushBlob(file)
+client.pushBlob(resource)
 ```
 
 Upload file from **web applications**
 
 ```js
 import { Client } from "ckanClient";
+import f11s from "data.js"
 
 const client = new Client('key', 'organization-name', 'dataset-name', 'api')
+const resource = f11s.open(file)
 
-client._pushBlob(file, onUploadProgress)
+client.pushBlob(resource, onUploadProgress)
 
 const onUploadProgress = progressEvent => {
   let progress = (progressEvent.loaded / progressEvent.total) * 100

--- a/README.md
+++ b/README.md
@@ -74,32 +74,26 @@ ckan-client-js
 Upload file from **NodeJS**
 
 ```js
-const { Client, Open } = require('./lib/index')
+const { Client } = require('./lib/index')
 
-const file = new Open.FileAPI.NodeFileSystemFile('file.csv')
 const client = new Client('key', 'organization-name', 'dataset-name', 'apiUrl')
 
-client
-  .ckanAuthz('http://localhost:5000')
-  .then(response => client.push(file, response.result.token))
+client._pushBlob(file)
 ```
 
 Upload file from **web applications**
 
 ```js
-import { Client, Open  } from "ckanClient";
+import { Client } from "ckanClient";
 
-const file = new Open.FileAPI.HTML5File(event.target.files[0])
 const client = new Client('key', 'organization-name', 'dataset-name', 'api')
+
+client._pushBlob(file, onUploadProgress)
 
 const onUploadProgress = progressEvent => {
   let progress = (progressEvent.loaded / progressEvent.total) * 100
   console.log(progress)
 }
-
-client
-  .ckanAuthz('http://localhost:5000')
-  .then(response => client.push(file, response.result.token, onUploadProgress))
 ```
 
 ## Build

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 const mapper = require('frictionless-ckan-mapper-js')
 const axios = require('axios')
-const f11s = require('data.js')
 
 const CkanAuthApi = require('./util/ckan-auth-api')
 const CkanUploadAPI = require('./util/ckan-upload-api')
@@ -23,7 +22,7 @@ class Client {
     this.api = api
   }
 
-  async _doBlobAuthz() {
+  async doBlobAuthz() {
     // Create the scope to send to CkanAuthz
     let scope = [`obj:${this.organizationId}/${this.datasetId}/*:write`]
 
@@ -79,12 +78,11 @@ class Client {
    * @param {File} file
    * @param {function} onProgress a callback function to track the progress
    */
-  async _pushBlob(file, onProgress) {
+  async pushBlob(resource, onProgress) {
     // Get the JWT token
-    const token = await this._doBlobAuthz()
+    const token = await this.doBlobAuthz()
 
-    const resource = f11s.open(file)
-    const resourceContent = resource.buffer
+    const resourceContent = await resource.buffer
 
     // Given the JWT token and file size, will return signed URL, verify URL and JWT token
     const lfs = await CkanAuthApi.requestFileUploadActions(

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const mapper = require('frictionless-ckan-mapper-js')
 const axios = require('axios')
+const f11s = require('data.js')
 
 const CkanAuthApi = require('./util/ckan-auth-api')
 const CkanUploadAPI = require('./util/ckan-upload-api')
@@ -22,20 +23,17 @@ class Client {
     this.api = api
   }
 
-  async ckanAuthz(url) {
+  async _doBlobAuthz() {
     // Create the scope to send to CkanAuthz
     let scope = [`obj:${this.organizationId}/${this.datasetId}/*:write`]
 
     // Get the JWT token from CkanAuthz, the user should provide the url
-    if (url) {
       const response = await CkanAuthApi.getJWTFromCkanAuthz(
-        url,
+        this.api,
         this.apiKey,
         scope
       )
-      return response
-    }
-    throw 'invalid URL argument'
+      return response.result.token
   }
 
   /**
@@ -79,15 +77,21 @@ class Client {
 
   /**
    * @param {File} file
-   * @param {string} token
+   * @param {function} onProgress a callback function to track the progress
    */
-  async push(file, token, onProgress) {
+  async _pushBlob(file, onProgress) {
+    // Get the JWT token
+    const token = await this._doBlobAuthz()
+
+    const resource = f11s.open(file)
+    const resourceContent = resource.buffer
+
     // Given the JWT token and file size, will return signed URL, verify URL and JWT token
     const lfs = await CkanAuthApi.requestFileUploadActions(
       this.api,
       token,
-      file.sha256(),
-      file.size(),
+      await resource.hashSha256,
+      resource.size,
       this.organizationId,
       this.datasetId
     )
@@ -95,19 +99,19 @@ class Client {
     const result = {
       oid: object.oid,
       size: object.size,
-      name: file.name(),
+      name: resource.descriptor.name,
       success: true,
       fileExists: false,
     }
 
     // Upload the file to cloud storage
     if (object.actions) {
-      await CkanUploadAPI.uploadToStorage(
+      await CkanUploadAPI.pushDataToBlobStorage(
         object.actions.upload,
-        file.content(),
+        resourceContent,
         onProgress
       )
-      await CkanUploadAPI.verifyUpload(lfs.objects[0].actions.verify, file)
+      await CkanUploadAPI.verifyUpload(lfs.objects[0].actions.verify, resource.hash, resource.size)
       return result
     } else {
       // File is already in storage

--- a/lib/util/ckan-upload-api.js
+++ b/lib/util/ckan-upload-api.js
@@ -2,7 +2,7 @@ const axios = require('axios')
 
 const CkanUploadAPI = {
   // Send a POST request with specific payload to the URL given by the Batch API response
-  uploadToStorage: async (actions, fileContent, onProgress) => {
+  pushDataToBlobStorage: async (actions, fileContent, onProgress) => {
     const { href, header } = actions
     const body = await fileContent
     const config = {
@@ -22,10 +22,10 @@ const CkanUploadAPI = {
   },
 
   // Get request to the verify URL given by the Batch API response
-  verifyUpload: async (action, file) => {
+  verifyUpload: async (action, hash, size) => {
     const body = JSON.stringify({
-      oid: await file.sha256(),
-      size: file.size(),
+      oid: hash,
+      size: size,
     })
     const config = {
       headers: {

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 const nock = require('nock')
+const f11s = require('data.js')
 
 const { Client, Open } = require('../lib/index')
 
@@ -137,7 +138,7 @@ test('Can instantiate Uploader', (t) => {
 })
 
 test('Can get JWT token', async (t) => {
-  const token = await client._doBlobAuthz()
+  const token = await client.doBlobAuthz()
 
   t.is(ckanAuthzMock.isDone(), true)
   t.is(token, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiIiLCJ== ")
@@ -145,8 +146,8 @@ test('Can get JWT token', async (t) => {
 
 test('Push works with packaged dataset', async (t) => {
   const path = 'test/fixtures/sample.csv'
-
-  await client._pushBlob(path)
+  const resource = f11s.open(path)
+  await client.pushBlob(resource)
 
   t.is(mainAuthzMock_forCloudStorageAccessGranterServiceMock.isDone(), true)
   t.is(cloudStorageMock.isDone(), true)

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -26,7 +26,6 @@ const accessGranterConfig = {
     ref: { name: 'refs/heads/contrib' },
     objects: [
       {
-        oid: '7b28186dca74020a82ed969101ff551f97aed110d8737cea4763ce5be3a38b47',
         size: 701,
       },
     ],
@@ -60,7 +59,7 @@ const file = new Open.NodeFileSystemFile('./test/fixtures/sample.csv')
 /**
  * Mock
  */
-const ckanAuthzMock = nock("http://localhost:5000")
+const ckanAuthzMock = nock("http://127.0.0.1")
   .persist()
   .post('/api/3/action/authz_authorize', ckanAuthzConfig.body)
   .reply(200, {
@@ -87,8 +86,8 @@ const mainAuthzMock_forCloudStorageAccessGranterServiceMock = nock(config.api)
     transfer: 'basic',
     objects: [
       {
-        oid: '8857053d874453bbe8e7613b09874e2d8fc9ddffd2130a579ca918301c31b369',
-        size: 123,
+        oid: "8857053d874453bbe8e7613b09874e2d8fc9ddffd2130a579ca918301c31b369",
+        size: 701,
         authenticated: true,
         actions: {
           upload: {
@@ -137,13 +136,18 @@ test('Can instantiate Uploader', (t) => {
   t.is(datapub.api, config.api)
 })
 
-test('Push works with packaged dataset', async (t) => {
-  const authzApi = "http://localhost:5000"
-  const token = await client.ckanAuthz(authzApi)
-                            .then(response => response.result.token )
-  await client.push(file, token)
+test('Can get JWT token', async (t) => {
+  const token = await client._doBlobAuthz()
 
   t.is(ckanAuthzMock.isDone(), true)
+  t.is(token, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiIiLCJ== ")
+})
+
+test('Push works with packaged dataset', async (t) => {
+  const path = 'test/fixtures/sample.csv'
+
+  await client._pushBlob(path)
+
   t.is(mainAuthzMock_forCloudStorageAccessGranterServiceMock.isDone(), true)
   t.is(cloudStorageMock.isDone(), true)
   t.is(verifyFileUploadMock.isDone(), true)


### PR DESCRIPTION
- [x] call the authz method in pushBlob method
- [x] refactor pushBlob method
- [x] using data.js to open the file in pushBlob method
- [x] fix tests

**NOTE:** The hash sha256 only available for FileInterface class in data.js

Acceptance https://github.com/datopian/ckan-client-js/issues/12

-  refactor push method
-  refactor authz method
