### PR TITLE
#11  - Feature: create() and push() dataset

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "trailingComma": "es5",
+  "tabWidth": 2,
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 79
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,21 @@ class Client {
     return response.data
   }
 
+  /**
+   * @param {(string|Object)} datasetNameOrMetadata
+   */
+  create(datasetNameOrMetadata) {
+    const datasetMetadata = typeof datasetNameOrMetadata === 'string'
+      ? { 'name': datasetNameOrMetadata }
+      : datasetNameOrMetadata
+
+    const ckanMetadata = frictionlessCkanMapper.packageFrictionlessToCkan(
+      datasetMetadata
+    )
+
+    return this.action('package_create', ckanMetadata)
+  }
+
   push(datasetMetadata) {
     const ckanMetadata = frictionlessCkanMapper.packageFrictionlessToCkan(
       datasetMetadata

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,9 +72,11 @@ class Client {
   }
 
   /**
+   * @async
    * @param {(string|Object)} datasetNameOrMetadata
+   * @return {Promise<Object>} The frictionless dataset
    */
-  create(datasetNameOrMetadata) {
+  async create(datasetNameOrMetadata) {
     const datasetMetadata =
       typeof datasetNameOrMetadata === 'string'
         ? { name: datasetNameOrMetadata }
@@ -84,17 +86,21 @@ class Client {
       datasetMetadata
     )
 
-    return this.action('package_create', ckanMetadata)
+    const response = await this.action('package_create', ckanMetadata)
+    return frictionlessCkanMapper.packageCkanToFrictionless(response.result)
   }
 
   /**
+   * @async
    * @param {Object} datasetMetadata
+   * @return {Promise<Object>} The frictionless dataset
    */
-  push(datasetMetadata) {
+  async push(datasetMetadata) {
     const ckanMetadata = frictionlessCkanMapper.packageFrictionlessToCkan(
       datasetMetadata
     )
-    return this.action('package_update', ckanMetadata)
+    const response = await this.action('package_update', ckanMetadata)
+    return frictionlessCkanMapper.packageCkanToFrictionless(response.result)
   }
 
   /**
@@ -113,7 +119,7 @@ class Client {
       true
     )
 
-    return mapper.packageCkanToFrictionless(response.result)
+    return frictionlessCkanMapper.packageCkanToFrictionless(response.result)
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,9 @@ class Client {
     return this.action('package_create', ckanMetadata)
   }
 
+  /**
+   * @param {Object} datasetMetadata
+   */
   push(datasetMetadata) {
     const ckanMetadata = frictionlessCkanMapper.packageFrictionlessToCkan(
       datasetMetadata

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
-const mapper = require('frictionless-ckan-mapper-js')
+const frictionlessCkanMapper = require('frictionless-ckan-mapper-js')
 const axios = require('axios')
-const f11s = require('data.js')
 
 const CkanAuthApi = require('./util/ckan-auth-api')
 const CkanUploadAPI = require('./util/ckan-upload-api')
@@ -75,13 +74,11 @@ class Client {
     return response.data
   }
 
-  push(actionType, payload) {
-    const file = f11s.open(payload)
-    const dataset = new f11s.Dataset({
-      ...file.descriptor,
-      resources: [],
-    })
-    return this.action(actionType, dataset.descriptor)
+  push(datasetMetadata) {
+    const ckanMetadata = frictionlessCkanMapper.packageFrictionlessToCkan(
+      datasetMetadata
+    )
+    return this.action('package_update', ckanMetadata)
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const { camelToSnakeCase } = require('./util/general')
 /**
  * @class Client.
  * @param {string} apiKey
- * @param {number} organizationId
+ * @param {string} organizationId
  * @param {string} datasetId
  * @param {string} api
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,12 @@
 const mapper = require('frictionless-ckan-mapper-js')
 const axios = require('axios')
+const f11s = require('data.js')
 
 const CkanAuthApi = require('./util/ckan-auth-api')
 const CkanUploadAPI = require('./util/ckan-upload-api')
 const ActionApi = require('./util/action-api')
 const Open = require('./file')
+
 const { camelToSnakeCase } = require('./util/general')
 
 /**
@@ -73,15 +75,20 @@ class Client {
     return response.data
   }
 
-  put(actionType, data) {
-    return ActionApi.action(this.api, this.apiKey, actionType, data)
+  push(actionType, payload) {
+    const file = f11s.open(payload)
+    const dataset = new f11s.Dataset({
+      ...file.descriptor,
+      resources: [],
+    })
+    return this.action(actionType, dataset.descriptor)
   }
 
   /**
    * @param {File} file
    * @param {string} token
    */
-  async push(file, token, onProgress) {
+  async pushBlob(file, token, onProgress) {
     // Given the JWT token and file size, will return signed URL, verify URL and JWT token
     const lfs = await CkanAuthApi.requestFileUploadActions(
       this.api,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "ava test/upload.test.js --verbose",
+    "test": "ava test/*.test.js --verbose",
     "test:watch": "ava test/*.test.js --verbose --watch",
     "build": "webpack",
     "build:watch": "webpack --watch"

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -25,7 +25,7 @@ test('get package', async (t) => {
   )
   const packageResponseConvertedToFrictionless = JSON.parse(
     await fs.readFileSync(
-      __dirname + '/mocks/getPackageFrictionlessResponse.json'
+      __dirname + '/mocks/frictionless-dataset-converted-from-ckan.json'
     )
   )
   // Testing dataname/id

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -184,7 +184,7 @@ const resourceMock = nock(config.api)
     }
   })
 
-test('create a dataset', async (t) => {
+test('action create a dataset', async (t) => {
   const client = new Client(
     config.authToken,
     config.organizationId,
@@ -192,7 +192,7 @@ test('create a dataset', async (t) => {
     config.api
   )
 
-  const response = await client.put('package_create', { "name": "my_dataset", "owner_org": "myorg"})
+  const response = await client.action('package_create', { "name": "my_dataset", "owner_org": "myorg"})
 
   t.is(client.api, config.api)
   t.is(packageCreateMock.isDone(), true)
@@ -201,15 +201,10 @@ test('create a dataset', async (t) => {
   t.is(response.result.organization.name, "myorg")
 })
 
-test('put metadata', async (t) => {
+test('push metadata', async (t) => {
   const path = 'test/fixtures/sample.csv'
-  const file = await f11s.open(path)
-  const dataset = new f11s.Dataset({
-    ...file.descriptor,
-    resources: [],
-  })
 
-  const response = await client.put('package_create', dataset.descriptor)
+  const response = await client.push('package_create', path)
 
   t.is(packageCreateMock.isDone(), true)
   t.is(response.success, true)
@@ -217,14 +212,14 @@ test('put metadata', async (t) => {
   t.deepEqual(response.result.resources, [])
 })
 
-test('put_resource create or update a resource', async (t) => {
+test('action create or update a resource', async (t) => {
   const path = 'test/fixtures/sample.csv'
   const file = await f11s.open(path)
 
   // Dataset must exist
   file.descriptor.package_id = "my_dataset_name"
 
-  const response = await client.put('resource_create', file.descriptor)
+  const response = await client.action('resource_create', file.descriptor)
 
   t.is(resourceMock.isDone(), true)
   t.is(response.success, true)

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -1,6 +1,8 @@
 const test = require('ava')
 const nock = require('nock')
 const f11s = require('data.js')
+const fs = require('fs')
+
 const { Client } = require('../lib/index')
 
 /**
@@ -20,210 +22,120 @@ const client = new Client(
   config.api
 )
 
-const metadataBody = {
-  path: 'test/fixtures/sample.csv',
-  pathType: 'local',
-  name: 'sample',
-  format: 'csv',
-  mediatype: 'text/csv',
-  encoding: 'UTF-8',
-  resources: [],
-}
-
-const resourceBody = {
-  path: 'test/fixtures/sample.csv',
-  pathType: 'local',
-  name: 'sample',
-  format: 'csv',
-  mediatype: 'text/csv',
-  encoding: 'UTF-8',
-  package_id: 'my_dataset_name'
-}
-
-/**
- * Mock
- */
-const packageCreateMock = nock(config.api)
-  .persist()
-  .post('/api/3/action/package_create', {
-    "name": config.datasetId,
-    "owner_org": config.organizationId,
-  })
-  .reply(200, {
-    help: 'http://localhost:5000/api/3/action/help_show?name=package_create',
-    success: true,
-    result: {
-      license_title: null,
-      maintainer: null,
-      relationships_as_object: [],
-      private: false,
-      maintainer_email: null,
-      num_tags: 0,
-      id: '3d27173c-dcbe-4c07-b1a9-70f683623f33',
-      metadata_created: '2020-09-11T00:12:07.550325',
-      metadata_modified: '2020-09-11T00:12:07.550334',
-      author: null,
-      author_email: null,
-      state: 'active',
-      version: null,
-      creator_user_id: 'ceb0d8c2-352b-4a6c-b2c8-2a1a4190192b',
-      type: 'dataset',
-      resources: [],
-      num_resources: 0,
-      tags: [],
-      groups: [],
-      license_id: null,
-      relationships_as_subject: [],
-      organization: {
-        description: 'my org',
-        created: '2020-04-14T13:27:47.434967',
-        title: 'myorg',
-        name: 'myorg',
-        is_organization: true,
-        state: 'active',
-        image_url: '',
-        revision_id: 'bff67202-a21e-470b-9b67-14e65ad85fa2',
-        type: 'organization',
-        id: 'f3fce98a-4750-4d09-a5d1-d5e1b995a2e8',
-        approval_status: 'approved',
-      },
-      name: 'my_dataset',
-      isopen: false,
-      url: null,
-      notes: null,
-      owner_org: 'f3fce98a-4750-4d09-a5d1-d5e1b995a2e8',
-      extras: [],
-      title: 'my_dataset',
-      revision_id: '3b10c815-d8aa-4726-ba06-bff4cb5874cb',
-    },
-  })
-
-const metadataMock = nock(config.api)
-  .persist()
-  .post('/api/3/action/package_create', metadataBody)
-  .reply(200, {
-    "help": "http://localhost:5000/api/3/action/help_show?name=package_create",
-    "success": true,
-    "result": {
-      "license_title": null,
-      "maintainer": null,
-      "relationships_as_object": [],
-      "private": false,
-      "maintainer_email": null,
-      "num_tags": 0,
-      "id": "9a25bbb9-a21f-430c-88c7-291a7bb37350",
-      "metadata_created": "2020-09-11T02:06:23.785055",
-      "metadata_modified": "2020-09-11T02:06:23.785059",
-      "author": null,
-      "author_email": null,
-      "state": "active",
-      "version": null,
-      "creator_user_id": "ceb0d8c2-352b-4a6c-b2c8-2a1a4190192b",
-      "type": "dataset",
-      "resources": [],
-      "num_resources": 0,
-      "tags": [],
-      "groups": [],
-      "license_id": null,
-      "relationships_as_subject": [],
-      "organization": {
-        "description": "my org",
-        "created": "2020-04-14T13:27:47.434967",
-        "title": "myorg",
-        "name": "myorg",
-        "is_organization": true,
-        "state": "active",
-        "image_url": "",
-        "revision_id": "bff67202-a21e-470b-9b67-14e65ad85fa2",
-        "type": "organization",
-        "id": "f3fce98a-4750-4d09-a5d1-d5e1b995a2e8",
-        "approval_status": "approved"
-      },
-      "name": "sample",
-      "isopen": false,
-      "url": null,
-      "notes": null,
-      "owner_org": "f3fce98a-4750-4d09-a5d1-d5e1b995a2e8",
-      "extras": [],
-      "title": "sample",
-      "revision_id": "341b8af7-3586-450a-b38a-98fb96a7afc4"
-    }
-  })
-
-const resourceMock = nock(config.api)
-  .persist()
-  .post('/api/3/action/resource_create', resourceBody)
-  .reply(200, {
-    "help": "http://localhost:5000/api/3/action/help_show?name=resource_create",
-    "success": true,
-    "result": {
-      "cache_last_updated": null,
-      "package_id": "3a1aa4af-9f00-490b-956e-2b063ed04961",
-      "datastore_active": false,
-      "id": "d5f496ce-2fe2-48d3-898f-3c0cc22f4015",
-      "size": null,
-      "encoding": "UTF-8",
-      "state": "active",
-      "hash": "",
-      "description": "",
-      "format": "CSV",
-      "mediatype": "text/csv",
-      "pathType": "local",
-      "mimetype_inner": null,
-      "url_type": null,
-      "path": "test/fixtures/sample.csv",
-      "mimetype": null,
-      "cache_url": null,
-      "name": "sample",
-      "created": "2020-09-11T02:51:20.697102",
-      "url": "",
-      "last_modified": null,
-      "position": 3,
-      "revision_id": "17aea680-6dc8-4ce4-ab8b-fec31996242c",
-      "resource_type": null
-    }
-  })
-
-test('action create a dataset', async (t) => {
-  const client = new Client(
-    config.authToken,
-    config.organizationId,
-    config.datasetId,
-    config.api
+test('push a metadata', async (t) => {
+  // Mock datasets
+  const frictionlessDataset = JSON.parse(
+    await fs.readFileSync(
+      __dirname + '/mocks/frictionless-dataset-converted-from-ckan.json'
+    )
+  )
+  const ckanDataset = JSON.parse(
+    await fs.readFileSync(__dirname + '/mocks/ckan-dataset.json')
   )
 
-  const response = await client.action('package_create', { "name": "my_dataset", "owner_org": "myorg"})
+  const packagePushMock = nock(config.api)
+    .persist()
+    .post('/api/3/action/package_update', (body) => {
+      t.deepEqual(body, {
+        notes: 'GDPs list',
+        url: 'https://datopian.com',
+        extras: [
+          {
+            key: 'schema',
+            value:
+              '{"fields":[{"name":"id","type":"integer"},{"name":"title","type":"string"}]}',
+          },
+        ],
+        name: 'gdp',
+        resources: [
+          {
+            name: 'data.csv',
+            url: 'http://someplace.com/data.csv',
+            size: 100,
+          },
+        ],
+      })
+      return true
+    })
+    .reply(200, {
+      help: 'http://localhost:5000/api/3/action/help_show?name=package_create',
+      success: true,
+      result: ckanDataset,
+    })
 
-  t.is(client.api, config.api)
-  t.is(packageCreateMock.isDone(), true)
-  t.is(response.success, true)
-  t.is(response.result.name, "my_dataset")
-  t.is(response.result.organization.name, "myorg")
+  const response = await client.push(frictionlessDataset)
+
+  t.is(packagePushMock.isDone(), true)
+  t.deepEqual(response, frictionlessDataset)
 })
 
-test('push metadata', async (t) => {
-  const path = 'test/fixtures/sample.csv'
+test('create a metadata', async (t) => {
+  // Mock datasets
+  const frictionlessDataset = JSON.parse(
+    await fs.readFileSync(
+      __dirname + '/mocks/frictionless-dataset-converted-from-ckan.json'
+    )
+  )
+  const ckanDataset = JSON.parse(
+    await fs.readFileSync(__dirname + '/mocks/ckan-dataset.json')
+  )
 
-  const response = await client.push('package_create', path)
+  // test with object
+  let packageCreateMock = nock(config.api)
+    .post('/api/3/action/package_create', (body) => {
+      t.deepEqual(body, {
+        notes: 'GDPs list',
+        url: 'https://datopian.com',
+        extras: [
+          {
+            key: 'schema',
+            value:
+              '{"fields":[{"name":"id","type":"integer"},{"name":"title","type":"string"}]}',
+          },
+        ],
+        name: 'gdp',
+        resources: [
+          {
+            name: 'data.csv',
+            url: 'http://someplace.com/data.csv',
+            size: 100,
+          },
+        ],
+      })
+      return true
+    })
+    .reply(200, {
+      help: 'http://localhost:5000/api/3/action/help_show?name=package_create',
+      success: true,
+      result: ckanDataset,
+    })
+
+  let response = await client.create(frictionlessDataset)
 
   t.is(packageCreateMock.isDone(), true)
-  t.is(response.success, true)
-  t.is(response.result.name, "sample")
-  t.deepEqual(response.result.resources, [])
-})
+  t.deepEqual(response, frictionlessDataset)
 
-test('action create or update a resource', async (t) => {
-  const path = 'test/fixtures/sample.csv'
-  const file = await f11s.open(path)
+  // test with string
+  packageCreateMock = nock(config.api)
+    .persist()
+    .post('/api/3/action/package_create', (body) => {
+      t.deepEqual(body, {
+        name: 'My Dataset Name',
+      })
+      return true
+    })
+    .reply(200, {
+      help: 'http://localhost:5000/api/3/action/help_show?name=package_create',
+      success: true,
+      result: {
+        name: 'My Dataset Name',
+      },
+    })
 
-  // Dataset must exist
-  file.descriptor.package_id = "my_dataset_name"
+  response = await client.create('My Dataset Name')
 
-  const response = await client.action('resource_create', file.descriptor)
-
-  t.is(resourceMock.isDone(), true)
-  t.is(response.success, true)
-  t.is(response.result.name, "sample")
-  t.is(response.result.format, "CSV")
-  t.is(response.result.mediatype, "text/csv")
+  t.is(packageCreateMock.isDone(), true)
+  t.deepEqual(response, {
+    name: 'My Dataset Name',
+  })
 })

--- a/test/mocks/ckan-dataset.json
+++ b/test/mocks/ckan-dataset.json
@@ -1,0 +1,22 @@
+{
+  "name": "gdp",
+  "url": "https://datopian.com",
+  "resources": [
+    {
+      "name": "data.csv",
+      "url": "http://someplace.com/data.csv",
+      "size": 100
+    }
+  ],
+  "description": "GDPs list",
+  "schema": {
+    "fields": [
+      { "name": "id", "type": "integer" },
+      { "name": "title", "type": "string" }
+    ]
+  },
+  "isopen": true,
+  "num_tags": 1,
+  "num_resources": 10,
+  "state": "active"
+}

--- a/test/mocks/frictionless-dataset-converted-from-ckan.json
+++ b/test/mocks/frictionless-dataset-converted-from-ckan.json
@@ -1,5 +1,6 @@
 {
   "description": "GDPs list",
+  "homepage": "https://datopian.com",
   "schema": {
     "fields": [
       { "name": "id", "type": "integer" },

--- a/test/mocks/getPackageCkanResponse.json
+++ b/test/mocks/getPackageCkanResponse.json
@@ -2,6 +2,7 @@
   "success": true,
   "result": {
     "name": "gdp",
+    "url": "https://datopian.com",
     "resources": [
       {
         "name": "data.csv",

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -141,7 +141,7 @@ test('Push works with packaged dataset', async (t) => {
   const authzApi = "http://localhost:5000"
   const token = await client.ckanAuthz(authzApi)
                             .then(response => response.result.token )
-  await client.push(file, token)
+  await client.pushBlob(file, token)
 
   t.is(ckanAuthzMock.isDone(), true)
   t.is(mainAuthzMock_forCloudStorageAccessGranterServiceMock.isDone(), true)


### PR DESCRIPTION
Inherited from #18. 

Adding only those points which are new, for previous implementation see #18

- [x] Changed `create()` and `push()` so that the return dataset is already converted into frictionless
- [x] Added JSDoc comments for the above functions to make it more clear to understand
- [x] Tests are written for `push()`, `create(obj)` and `create(str)` use cases
- [x] Made some small refactoring in the tests. Ideally this would be better to make in a separate PR, but since we are in rush included it here. 

cc: @mariorodeghiero, @anuveyatsu 
