### PR TITLE
[fix][s]: the hash should be resource.descriptor.hash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,7 @@ class Client {
     const lfs = await CkanAuthApi.requestFileUploadActions(
       this.api,
       token,
-      await resource.hashSha256,
+      resource.descriptor.hash,
       resource.size,
       this.organizationId,
       this.datasetId
@@ -172,7 +172,7 @@ class Client {
       )
       await CkanUploadAPI.verifyUpload(
         lfs.objects[0].actions.verify,
-        resource.hash,
+        resource.descriptor.hash,
         resource.size
       )
       return result


### PR DESCRIPTION
This is a small change in `await resource.hashSha256` returns `undefined` as a hash.

I code should be `resource.descriptor.hash`


I think we need to check the hash method in data.js because for the sample.csv file I receive `+fmT1a/ovuOXWfjTkXhWFjIAKB3t+5AHMx0HLxuXzQM=` and I tested the same file online and I receive another hash.

Hash generate online:

![Screenshot from 2020-09-15 15-43-12](https://user-images.githubusercontent.com/24671133/93253069-bbf2c680-f76c-11ea-946a-78b8efdaa055.png)
