### PR TITLE
Change progress calculation to indicate progress of entire file

### DIFF
--- a/lib/lfs-client.js
+++ b/lib/lfs-client.js
@@ -227,7 +227,7 @@ class GitLfsMultipartTransfer {
     this._externalProgressCallback = onProgress;
     this._actions = actions;
 
-    this._bytesToUpload = 0;
+    this._bytesTotal = 0;
     this._bytesUploaded = 0;
   }
 
@@ -247,8 +247,8 @@ class GitLfsMultipartTransfer {
     }
 
     const parts = this._actions.parts || [];
-    this._bytesToUpload = this._getBytesToUpload(parts);
-    this._bytesUploaded = 0;
+    this._bytesTotal = this._file.size;
+    this._bytesUploaded = this._bytesTotal - this._getBytesToUpload(parts);
     for (let i = 0; i < parts.length; i++) {
       console.log(`Uploading part ${i + 1}/${parts.length}`);
       response = await this._uploadPart(parts[i]);
@@ -410,24 +410,21 @@ class GitLfsMultipartTransfer {
    * @private
    */
   _onUploadProgress(progressEvent) {
+    if (! this._externalProgressCallback) {
+      return;
+    }
     let loaded = this._bytesUploaded;
-    let total = this._bytesToUpload;
+    let total = this._bytesTotal;
     if (progressEvent.lengthComputable) {
-      const progressPct = Math.round(progressEvent.loaded / progressEvent.total * 100);
-      if (progressPct % 50 === 0) {
-        console.log(`Part upload progress is at ${progressPct}%`);
-      }
       loaded += progressEvent.loaded;
     }
 
-    if (this._externalProgressCallback) {
-      const realProgress = new ProgressEvent('ProgressEvent', {
-        lengthComputable: true,
-        loaded,
-        total,
-      });
-      this._externalProgressCallback(realProgress);
-    }
+    const realProgress = new ProgressEvent('ProgressEvent', {
+      lengthComputable: true,
+      loaded,
+      total,
+    });
+    this._externalProgressCallback(realProgress);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckan-client",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "ckan-client-js is a SDK in javascript for uploading files and updating metastore",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
In multipart uploads; Instead of showing progress based on only the parts left to upload. This affects uploads where parts of the file has already been uploaded.