### PR TITLE
Include the file name as part of the payload sent the to LFS server

### DIFF
--- a/lib/lfs-client.js
+++ b/lib/lfs-client.js
@@ -77,6 +77,10 @@ class GitLfsClient {
         {
           oid: await _getFileHash(file, 'sha256'),
           size: file.size,
+          extra: {
+            filename: file.fileName
+          }
+
         },
       ],
     }

--- a/lib/lfs-client.js
+++ b/lib/lfs-client.js
@@ -77,12 +77,11 @@ class GitLfsClient {
         {
           oid: await _getFileHash(file, 'sha256'),
           size: file.size,
-          extra: {
-            filename: file.fileName
-          }
-
         },
       ],
+    }
+    if (file.fileName) {
+      body['objects'][0]['extra'] = {'filename': file.fileName}
     }
     const config = {
       headers: {


### PR DESCRIPTION
This is included in the `extra` property, which Giftless supports for additional parameters.

This is part of a multi-repo change to allow setting proper `Content-type` and `Content-disposition` headers. See https://github.com/datopian/giftless/pull/90 and https://github.com/datopian/giftless/discussions/88 for additional discussion