### PR TITLE
Add support for headers when calling action API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,14 +12,17 @@ const { camelToSnakeCase } = require('./util/general')
  * @param {string} organizationId
  * @param {string} datasetId
  * @param {string} api
+ * @param {string} lfsServerUrl
+ * @param {Object <String, String>} headers
  */
 class Client {
-  constructor(apiKey, organizationId, datasetId, api, lfsServerUrl) {
+  constructor(apiKey, organizationId, datasetId, api, lfsServerUrl, headers) {
     this.apiKey = apiKey
     this.organizationId = organizationId
     this.datasetId = datasetId
     this.api = api
     this.lfsServerUrl = lfsServerUrl
+    this.headers = headers
   }
 
   async getUploadAuthToken() {
@@ -30,7 +33,8 @@ class Client {
     const response = await CkanAuthApi.getJWTFromCkanAuthz(
       this.api,
       this.apiKey,
-      scope
+      scope,
+      this.headers
     )
     return response.result.token
   }
@@ -60,6 +64,7 @@ class Client {
       headers: {
         'Content-Type': 'application/json;charset=utf-8',
         Authorization: this.apiKey,
+        ...this.headers,
       },
     }
     let response

--- a/lib/util/ckan-auth-api.js
+++ b/lib/util/ckan-auth-api.js
@@ -2,12 +2,13 @@ const axios = require('axios')
 
 const CkanAuthApi = {
   // Get an authorization token from ckanext-authz-service
-  getJWTFromCkanAuthz: async (baseUrl, authToken, scope) => {
+  getJWTFromCkanAuthz: async (baseUrl, authToken, scope, headers) => {
     const path = '/api/3/action/authz_authorize'
     const config = {
       headers: {
         'Content-Type': 'application/json;charset=utf-8',
         Authorization: authToken,
+        ...headers,
       },
     }
     const body = {


### PR DESCRIPTION
This PR adds the option to send custom headers when calling to the CKAN API.

This will be useful to add CSRF tokens when using this library to develop custom features for an extension.